### PR TITLE
Fix await within ch1 createTodo

### DIFF
--- a/chapter_1:oak/controllers/todo.ts
+++ b/chapter_1:oak/controllers/todo.ts
@@ -23,7 +23,8 @@ export default {
   createTodo: async (
     { request, response }: { request: any; response: any },
   ) => {
-    const body = await request.body();
+    const { value : todoBody } = await request.body();
+    const todo: Todo = todoBody;
     if (!request.hasBody) {
       response.status = 400;
       response.body = {
@@ -38,7 +39,7 @@ export default {
     // new data added.
     let newTodo: Todo = {
       id: v4.generate(),
-      todo: body.value.todo,
+      todo: (await todo).todo,
       isCompleted: false,
     };
     let data = [...todos, newTodo];


### PR DESCRIPTION
Adds an await to the todo string value as well as enforces the todo body type.

Results:
```json
{
    "success": true,
    "data": [
        {
            "id": "b592b4db-f032-42be-9fb5-f715d58846ff",
            "todo": "walk dog",
            "isCompleted": true
        },
        {
            "id": "a7e926ec-25a5-4c84-a767-aec40ad49949",
            "todo": "eat food",
            "isCompleted": false
        },
        {
            "id": "475b7262-c306-45fb-afbd-76a57992e271",
            "todo": "exercise",
            "isCompleted": true
        },
        {
            "id": "70e6dfb3-820b-4f2c-b974-761860e61858",
            "todo": "read a book",
            "isCompleted": false
        },
        {
            "id": "54d21545-52ec-4371-b9f6-317a9ac1c691",
            "todo": "eat a lama",
            "isCompleted": false
        }
    ]
}
```

Closes #3 